### PR TITLE
Fixes for multimodules templates

### DIFF
--- a/surf_mvp_coordinatable_alert_custom_headers/Code/Configurator/module_configurator.swift.liquid
+++ b/surf_mvp_coordinatable_alert_custom_headers/Code/Configurator/module_configurator.swift.liquid
@@ -1,0 +1,21 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import UIKit
+
+final class {{ module_info.name }}ModuleConfigurator {
+
+    func configure() -> ({{ module_info.name }}Controller, {{ module_info.name }}ModuleOutput) {
+
+        // TODO: Change title and message
+        let view = {{ module_info.name }}Controller(title: nil, message: nil, preferredStyle: .alert)
+        let presenter = {{ module_info.name }}Presenter()
+
+        presenter.view = view
+        view.output = presenter
+
+        return (view, presenter)
+    }
+
+}

--- a/surf_mvp_coordinatable_alert_custom_headers/Code/Presenter/module_input.swift.liquid
+++ b/surf_mvp_coordinatable_alert_custom_headers/Code/Presenter/module_input.swift.liquid
@@ -1,0 +1,6 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+protocol {{ module_info.name }}ModuleInput: class {
+}

--- a/surf_mvp_coordinatable_alert_custom_headers/Code/Presenter/module_output.swift.liquid
+++ b/surf_mvp_coordinatable_alert_custom_headers/Code/Presenter/module_output.swift.liquid
@@ -1,0 +1,6 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+protocol {{ module_info.name }}ModuleOutput: class {
+}

--- a/surf_mvp_coordinatable_alert_custom_headers/Code/Presenter/presenter.swift.liquid
+++ b/surf_mvp_coordinatable_alert_custom_headers/Code/Presenter/presenter.swift.liquid
@@ -1,0 +1,23 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+final class {{ module_info.name }}Presenter: {{ module_info.name }}ModuleOutput {
+
+    // MARK: - {{ module_info.name }}ModuleOutput
+
+    // MARK: - Properties
+
+    weak var view: {{ module_info.name }}ViewInput?
+
+}
+
+// MARK: - {{ module_info.name }}ModuleInput
+
+extension {{ module_info.name }}Presenter: {{ module_info.name }}ModuleInput {
+}
+
+// MARK: - {{ module_info.name }}ViewOutput
+
+extension {{ module_info.name }}Presenter: {{ module_info.name }}ViewOutput {
+}

--- a/surf_mvp_coordinatable_alert_custom_headers/Code/View/view_controller.swift.liquid
+++ b/surf_mvp_coordinatable_alert_custom_headers/Code/View/view_controller.swift.liquid
@@ -1,0 +1,18 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import UIKit
+
+final class {{ module_info.name }}Controller: UIAlertController {
+
+    // MARK: - Properties
+
+    var output: {{ module_info.name }}ViewOutput?
+
+}
+
+// MARK: - {{ module_info.name }}ViewInput
+
+extension {{ module_info.name }}Controller: {{ module_info.name }}ViewInput {
+}

--- a/surf_mvp_coordinatable_alert_custom_headers/Code/View/view_input.swift.liquid
+++ b/surf_mvp_coordinatable_alert_custom_headers/Code/View/view_input.swift.liquid
@@ -1,0 +1,6 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+protocol {{ module_info.name }}ViewInput: class {
+}

--- a/surf_mvp_coordinatable_alert_custom_headers/Code/View/view_output.swift.liquid
+++ b/surf_mvp_coordinatable_alert_custom_headers/Code/View/view_output.swift.liquid
@@ -1,0 +1,6 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+protocol {{ module_info.name }}ViewOutput: class {
+}

--- a/surf_mvp_coordinatable_alert_custom_headers/Tests/Configurator/module_configurator_tests.swift.liquid
+++ b/surf_mvp_coordinatable_alert_custom_headers/Tests/Configurator/module_configurator_tests.swift.liquid
@@ -1,0 +1,19 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import XCTest
+@testable import {{ module_info.product_module_name  }}
+
+final class {{ module_info.name }}ModuleConfiguratorTests: XCTestCase {
+
+    // MARK: - Main tests
+
+    func testDeallocation() {
+        assertDeallocation(of: {
+            let (view, output) = {{ module_info.name }}ModuleConfigurator().configure()
+            return (view, [output])
+        })
+    }
+
+}

--- a/surf_mvp_coordinatable_alert_custom_headers/surf_mvp_coordinatable_alert_custom_headers.rambaspec
+++ b/surf_mvp_coordinatable_alert_custom_headers/surf_mvp_coordinatable_alert_custom_headers.rambaspec
@@ -1,0 +1,29 @@
+# Template information section
+name: "surf_mvp_coordinatable_alert_custom_headers"
+summary: "Template for creating MVP alert modules with coordinator."
+author: "Serge Nanaev"
+version: "1.0.0"
+license: "MIT"
+
+# The declarations for code files
+
+code_files:
+# Configurator
+- {name: Configurator/ModuleConfigurator.swift, path: Code/Configurator/module_configurator.swift.liquid}
+
+# Presenter layer
+- {name: Presenter/Presenter.swift, path: Code/Presenter/presenter.swift.liquid}
+- {name: Presenter/ModuleInput.swift, path: Code/Presenter/module_input.swift.liquid}
+- {name: Presenter/ModuleOutput.swift, path: Code/Presenter/module_output.swift.liquid}
+
+# View layer
+- {name: View/Controller.swift, path: Code/View/view_controller.swift.liquid}
+- {name: View/ViewInput.swift,  path: Code/View/view_input.swift.liquid}
+- {name: View/ViewOutput.swift, path: Code/View/view_output.swift.liquid}
+
+# The declarations for test files
+
+test_files:
+
+# Configurators tests
+- {name: Configurator/ModuleConfiguratorTests.swift, path: Tests/Configurator/module_configurator_tests.swift.liquid}

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Configurator/module_configurator.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Configurator/module_configurator.swift.liquid
@@ -1,0 +1,27 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import UIKit
+
+public final class {{ module_info.name }}ModuleConfigurator {
+
+    // MARK: - Initialization
+
+    public init() {}
+
+    // MARK: - Public Methods
+
+    public func configure() -> (UIAlertController, {{ module_info.name }}ModuleOutput) {
+
+        // TODO: Change title and message
+        let view = {{ module_info.name }}Controller(title: nil, message: nil, preferredStyle: .alert)
+        let presenter = {{ module_info.name }}Presenter()
+
+        presenter.view = view
+        view.output = presenter
+
+        return (view, presenter)
+    }
+
+}

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Presenter/module_input.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Presenter/module_input.swift.liquid
@@ -1,0 +1,6 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+public protocol {{ module_info.name }}ModuleInput: class {
+}

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Presenter/module_output.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Presenter/module_output.swift.liquid
@@ -1,0 +1,6 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+public protocol {{ module_info.name }}ModuleOutput: class {
+}

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Presenter/presenter.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Presenter/presenter.swift.liquid
@@ -1,0 +1,23 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+final class {{ module_info.name }}Presenter: {{ module_info.name }}ModuleOutput {
+
+    // MARK: - {{ module_info.name }}ModuleOutput
+
+    // MARK: - Properties
+
+    weak var view: {{ module_info.name }}ViewInput?
+
+}
+
+// MARK: - {{ module_info.name }}ModuleInput
+
+extension {{ module_info.name }}Presenter: {{ module_info.name }}ModuleInput {
+}
+
+// MARK: - {{ module_info.name }}ViewOutput
+
+extension {{ module_info.name }}Presenter: {{ module_info.name }}ViewOutput {
+}

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Code/View/view_controller.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Code/View/view_controller.swift.liquid
@@ -1,0 +1,18 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import UIKit
+
+final class {{ module_info.name }}Controller: UIAlertController {
+
+    // MARK: - Properties
+
+    var output: {{ module_info.name }}ViewOutput?
+
+}
+
+// MARK: - {{ module_info.name }}ViewInput
+
+extension {{ module_info.name }}Controller: {{ module_info.name }}ViewInput {
+}

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Code/View/view_input.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Code/View/view_input.swift.liquid
@@ -1,0 +1,6 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+protocol {{ module_info.name }}ViewInput: class {
+}

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Code/View/view_output.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Code/View/view_output.swift.liquid
@@ -1,0 +1,6 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+protocol {{ module_info.name }}ViewOutput: class {
+}

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Tests/Configurator/module_configurator_tests.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Tests/Configurator/module_configurator_tests.swift.liquid
@@ -1,0 +1,20 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import XCTest
+import {{ custom_parameters.testTarget }}Flow
+@testable import {{ module_info.product_module_name }}
+
+final class {{ module_info.name }}ModuleConfiguratorTests: XCTestCase {
+
+    // MARK: - Main tests
+
+    func testDeallocation() {
+        assertDeallocation(of: {
+            let (view, output) = {{ module_info.name }}ModuleConfigurator().configure()
+            return (view, [output])
+        })
+    }
+
+}

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/surf_mvp_coordinatable_alert_mm_custom_headers.rambaspec
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/surf_mvp_coordinatable_alert_mm_custom_headers.rambaspec
@@ -1,0 +1,29 @@
+# Template information section
+name: "surf_mvp_coordinatable_alert_mm_custom_headers"
+summary: "Template for creating MVP alert modules with coordinator."
+author: "Serge Nanaev"
+version: "1.0.0"
+license: "MIT"
+
+# The declarations for code files
+
+code_files:
+# Configurator
+- {name: Configurator/ModuleConfigurator.swift, path: Code/Configurator/module_configurator.swift.liquid}
+
+# Presenter layer
+- {name: Presenter/Presenter.swift, path: Code/Presenter/presenter.swift.liquid}
+- {name: Presenter/ModuleInput.swift, path: Code/Presenter/module_input.swift.liquid}
+- {name: Presenter/ModuleOutput.swift, path: Code/Presenter/module_output.swift.liquid}
+
+# View layer
+- {name: View/Controller.swift, path: Code/View/view_controller.swift.liquid}
+- {name: View/ViewInput.swift,  path: Code/View/view_input.swift.liquid}
+- {name: View/ViewOutput.swift, path: Code/View/view_output.swift.liquid}
+
+# The declarations for test files
+
+test_files:
+
+# Configurators tests
+- {name: Configurator/ModuleConfiguratorTests.swift, path: Tests/Configurator/module_configurator_tests.swift.liquid}

--- a/surf_mvp_coordinatable_module_custom_headers/Code/Configurator/module_configurator.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Code/Configurator/module_configurator.swift.liquid
@@ -1,0 +1,19 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import UIKit
+
+final class {{ module_info.name }}ModuleConfigurator {
+
+    func configure() -> (UIViewController, {{ module_info.name }}ModuleOutput) {
+        let view = {{ module_info.name }}ViewController()
+        let presenter = {{ module_info.name }}Presenter()
+
+        presenter.view = view
+        view.output = presenter
+
+        return (view, presenter)
+    }
+
+}

--- a/surf_mvp_coordinatable_module_custom_headers/Code/Presenter/module_input.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Code/Presenter/module_input.swift.liquid
@@ -1,0 +1,6 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+protocol {{ module_info.name }}ModuleInput: class {
+}

--- a/surf_mvp_coordinatable_module_custom_headers/Code/Presenter/module_output.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Code/Presenter/module_output.swift.liquid
@@ -1,0 +1,6 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+protocol {{ module_info.name }}ModuleOutput: class {
+}

--- a/surf_mvp_coordinatable_module_custom_headers/Code/Presenter/presenter.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Code/Presenter/presenter.swift.liquid
@@ -1,0 +1,28 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+final class {{ module_info.name }}Presenter: {{ module_info.name }}ModuleOutput {
+
+    // MARK: - {{ module_info.name }}ModuleOutput
+
+    // MARK: - Properties
+
+    weak var view: {{ module_info.name }}ViewInput?
+
+}
+
+// MARK: - {{ module_info.name }}ModuleInput
+
+extension {{ module_info.name }}Presenter: {{ module_info.name }}ModuleInput {
+}
+
+// MARK: - {{ module_info.name }}ViewOutput
+
+extension {{ module_info.name }}Presenter: {{ module_info.name }}ViewOutput {
+
+    func viewLoaded() {
+        view?.setupInitialState()
+    }
+
+}

--- a/surf_mvp_coordinatable_module_custom_headers/Code/View/view_controller.storyboard.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Code/View/view_controller.storyboard.liquid
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="h3k-bK-TNO">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <scene sceneID="PlN-iW-H7B">
+            <objects>
+                <viewController id="h3k-bK-TNO" customClass="{{ module_info.name }}ViewController" customModule="{{ module_info.project_name }}" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="cA6-JB-jfU">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="YWU-9O-L7t"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="psv-Wb-mBc" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="575" y="-231"/>
+        </scene>
+    </scenes>
+</document>

--- a/surf_mvp_coordinatable_module_custom_headers/Code/View/view_controller.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Code/View/view_controller.swift.liquid
@@ -1,0 +1,29 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import UIKit
+
+final class {{ module_info.name }}ViewController: UIViewController {
+
+    // MARK: - Properties
+
+    var output: {{ module_info.name }}ViewOutput?
+
+    // MARK: - UIViewController
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        output?.viewLoaded()
+    }
+
+}
+
+// MARK: - {{ module_info.name }}ViewInput
+
+extension {{ module_info.name }}ViewController: {{ module_info.name }}ViewInput {
+
+    func setupInitialState() {
+    }
+
+}

--- a/surf_mvp_coordinatable_module_custom_headers/Code/View/view_controller.xib.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Code/View/view_controller.xib.liquid
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_0" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customModule="{{ module_info.project_name }}" customClass="{{ module_info.name }}ViewController" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="iN0-l3-epB" id="Q3p-Ee-1CD"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </view>
+    </objects>
+</document>

--- a/surf_mvp_coordinatable_module_custom_headers/Code/View/view_input.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Code/View/view_input.swift.liquid
@@ -1,0 +1,8 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+protocol {{ module_info.name }}ViewInput: class {
+    /// Method for setup initial state of view
+    func setupInitialState()
+}

--- a/surf_mvp_coordinatable_module_custom_headers/Code/View/view_output.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Code/View/view_output.swift.liquid
@@ -1,0 +1,8 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+protocol {{ module_info.name }}ViewOutput {
+    /// Notify presenter that view is ready
+    func viewLoaded()
+}

--- a/surf_mvp_coordinatable_module_custom_headers/Tests/Configurator/module_configurator_tests.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Tests/Configurator/module_configurator_tests.swift.liquid
@@ -1,0 +1,19 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import XCTest
+@testable import {{ module_info.product_module_name  }}
+
+final class {{ module_info.name }}ModuleConfiguratorTests: XCTestCase {
+
+    // MARK: - Main tests
+
+    func testDeallocation() {
+        assertDeallocation(of: {
+            let (view, output) = {{ module_info.name }}ModuleConfigurator().configure()
+            return (view, [output])
+        })
+    }
+
+}

--- a/surf_mvp_coordinatable_module_custom_headers/Tests/Presenter/presenter_tests.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Tests/Presenter/presenter_tests.swift.liquid
@@ -1,0 +1,55 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import XCTest
+@testable import {{ module_info.product_module_name  }}
+
+final class {{ module_info.name }}PresenterTest: XCTestCase {
+
+    // MARK: - Properties
+
+    private var presenter: {{ module_info.name }}Presenter?
+    private var view: MockViewController?
+    private var output: MockModuleOutput?
+
+    // MARK: - XCTestCase
+
+    override func setUp() {
+        super.setUp()
+        presenter = {{ module_info.name }}Presenter()
+        output = MockModuleOutput()
+        view = MockViewController()
+        presenter?.view = view
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        presenter = nil
+        view = nil
+    }
+
+    // MARK: - Main tests
+
+    func testThatPresenterHandlesViewLoadedEvent() {
+        // when 
+        presenter?.viewLoaded()
+        // then
+        XCTAssertTrue((presenter?.view as? MockViewController)?.setupInitialStateWasCalled == true)
+    }
+
+    // MARK: - Mocks
+
+    private final class MockViewController: {{ module_info.name }}ViewInput {
+        var setupInitialStateWasCalled: Bool = false
+
+        func setupInitialState() {
+            setupInitialStateWasCalled = true
+        }
+    }
+
+    private final class MockModuleOutput {
+
+    }
+
+}

--- a/surf_mvp_coordinatable_module_custom_headers/Tests/View/view_tests.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Tests/View/view_tests.swift.liquid
@@ -1,0 +1,49 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import XCTest
+@testable import {{ module_info.product_module_name }}
+
+final class {{ module_info.name }}ViewTests: XCTestCase {
+
+    // MARK: - Properties
+
+    private var view: {{ module_info.name }}ViewController?
+    private var output: {{ module_info.name }}ViewOutputMock?
+
+    // MARK: - XCTestCase
+
+    override func setUp() {
+        super.setUp()
+        view = {{ module_info.name }}ViewController()
+        output = {{ module_info.name }}ViewOutputMock()
+        view?.output = output
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        view = nil
+        output = nil
+    }
+
+    // MARK: - Main tests
+
+    func testThatViewNotifiesPresenterOnDidLoad() {
+        // when
+        self.view?.viewDidLoad()
+        // then
+        XCTAssert(self.output?.viewLoadedWasCalled == true)
+    }
+
+    // MARK: - Mocks
+
+    final class {{ module_info.name }}ViewOutputMock: {{ module_info.name }}ViewOutput {
+        var viewLoadedWasCalled: Bool = false
+
+        func viewLoaded() {
+            viewLoadedWasCalled = true
+        }
+    }
+
+}

--- a/surf_mvp_coordinatable_module_custom_headers/surf_mvp_coordinatable_module_custom_headers.rambaspec
+++ b/surf_mvp_coordinatable_module_custom_headers/surf_mvp_coordinatable_module_custom_headers.rambaspec
@@ -1,0 +1,36 @@
+# Template information section
+name: "surf_mvp_coordinatable_module_custom_headers"
+summary: "Template for creating MVP modules with coordinator."
+author: "Serge Nanaev"
+version: "1.0.0"
+license: "MIT"
+
+# The declarations for code files
+
+code_files:
+# Configurator
+- {name: Configurator/ModuleConfigurator.swift, path: Code/Configurator/module_configurator.swift.liquid}
+
+# Presenter layer
+- {name: Presenter/Presenter.swift, path: Code/Presenter/presenter.swift.liquid}
+- {name: Presenter/ModuleInput.swift, path: Code/Presenter/module_input.swift.liquid}
+- {name: Presenter/ModuleOutput.swift, path: Code/Presenter/module_output.swift.liquid}
+
+# View layer
+- {name: View/ViewController.swift, path: Code/View/view_controller.swift.liquid}
+- {name: View/ViewController.xib, path: Code/View/view_controller.xib.liquid}
+- {name: View/ViewInput.swift,  path: Code/View/view_input.swift.liquid}
+- {name: View/ViewOutput.swift, path: Code/View/view_output.swift.liquid}
+
+# The declarations for test files
+
+test_files:
+
+# Configurators tests
+- {name: Configurator/ModuleConfiguratorTests.swift, path: Tests/Configurator/module_configurator_tests.swift.liquid}
+
+# Presenter tests
+#- {name: Presenter/PresenterTests.swift, path: Tests/Presenter/presenter_tests.swift.liquid}
+
+# View tests
+#- {name: View/ViewTests.swift, path: Tests/View/view_tests.swift.liquid}

--- a/surf_mvp_coordinatable_module_mm/Code/Configurator/module_configurator.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm/Code/Configurator/module_configurator.swift.liquid
@@ -8,7 +8,7 @@
 
 import UIKit
 
-final public class {{ module_info.name }}ModuleConfigurator {
+public final class {{ module_info.name }}ModuleConfigurator {
 
     // MARK: - Initialization
 

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/Configurator/module_configurator.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/Configurator/module_configurator.swift.liquid
@@ -1,0 +1,25 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import UIKit
+
+public final class {{ module_info.name }}ModuleConfigurator {
+
+    // MARK: - Initialization
+
+    public init() {}
+
+    // MARK: - Public Methods
+
+    public func configure() -> (UIViewController, {{ module_info.name }}ModuleOutput) {
+        let view = {{ module_info.name }}ViewController(nibName: {{ module_info.name }}ViewController.nameOfClass, bundle: Bundle(for: {{ module_info.name }}ViewController.self))
+        let presenter = {{ module_info.name }}Presenter()
+
+        presenter.view = view
+        view.output = presenter
+
+        return (view, presenter)
+    }
+
+}

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/Presenter/module_input.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/Presenter/module_input.swift.liquid
@@ -1,0 +1,6 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+public protocol {{ module_info.name }}ModuleInput: class {
+}

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/Presenter/module_output.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/Presenter/module_output.swift.liquid
@@ -1,0 +1,6 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+public protocol {{ module_info.name }}ModuleOutput: class {
+}

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/Presenter/presenter.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/Presenter/presenter.swift.liquid
@@ -1,0 +1,28 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+final class {{ module_info.name }}Presenter: {{ module_info.name }}ModuleOutput {
+
+    // MARK: - {{ module_info.name }}ModuleOutput
+
+    // MARK: - Properties
+
+    weak var view: {{ module_info.name }}ViewInput?
+
+}
+
+// MARK: - {{ module_info.name }}ModuleInput
+
+extension {{ module_info.name }}Presenter: {{ module_info.name }}ModuleInput {
+}
+
+// MARK: - {{ module_info.name }}ViewOutput
+
+extension {{ module_info.name }}Presenter: {{ module_info.name }}ViewOutput {
+
+    func viewLoaded() {
+        view?.setupInitialState()
+    }
+
+}

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/View/view_controller.storyboard.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/View/view_controller.storyboard.liquid
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="h3k-bK-TNO">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <scene sceneID="PlN-iW-H7B">
+            <objects>
+                <viewController id="h3k-bK-TNO" customClass="{{ module_info.name }}ViewController" customModule="{{ module_info.project_name }}" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="cA6-JB-jfU">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="YWU-9O-L7t"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="psv-Wb-mBc" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="575" y="-231"/>
+        </scene>
+    </scenes>
+</document>

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/View/view_controller.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/View/view_controller.swift.liquid
@@ -1,0 +1,29 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import UIKit
+
+final class {{ module_info.name }}ViewController: UIViewController {
+
+    // MARK: - Properties
+
+    var output: {{ module_info.name }}ViewOutput?
+
+    // MARK: - UIViewController
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        output?.viewLoaded()
+    }
+
+}
+
+// MARK: - {{ module_info.name }}ViewInput
+
+extension {{ module_info.name }}ViewController: {{ module_info.name }}ViewInput {
+
+    func setupInitialState() {
+    }
+
+}

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/View/view_controller.xib.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/View/view_controller.xib.liquid
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_0" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customModule="{{ module_info.project_name }}" customClass="{{ module_info.name }}ViewController" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="iN0-l3-epB" id="Q3p-Ee-1CD"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </view>
+    </objects>
+</document>

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/View/view_input.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/View/view_input.swift.liquid
@@ -1,0 +1,8 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+protocol {{ module_info.name }}ViewInput: class {
+    /// Method for setup initial state of view
+    func setupInitialState()
+}

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/View/view_output.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/View/view_output.swift.liquid
@@ -1,0 +1,8 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+protocol {{ module_info.name }}ViewOutput {
+    /// Notify presenter that view is ready
+    func viewLoaded()
+}

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Tests/Configurator/module_configurator_tests.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Tests/Configurator/module_configurator_tests.swift.liquid
@@ -1,0 +1,20 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import XCTest
+import {{ custom_parameters.testTarget }}Flow
+@testable import {{ module_info.product_module_name }}
+
+final class {{ module_info.name }}ModuleConfiguratorTests: XCTestCase {
+
+    // MARK: - Main tests
+
+    func testDeallocation() {
+        assertDeallocation(of: {
+            let (view, output) = {{ module_info.name }}ModuleConfigurator().configure()
+            return (view, [output])
+        })
+    }
+
+}

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Tests/Presenter/presenter_tests.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Tests/Presenter/presenter_tests.swift.liquid
@@ -1,0 +1,55 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import XCTest
+@testable import {{ module_info.product_module_name  }}
+
+final class {{ module_info.name }}PresenterTest: XCTestCase {
+
+    // MARK: - Properties
+
+    private var presenter: {{ module_info.name }}Presenter?
+    private var view: MockViewController?
+    private var output: MockModuleOutput?
+
+    // MARK: - XCTestCase
+
+    override func setUp() {
+        super.setUp()
+        presenter = {{ module_info.name }}Presenter()
+        output = MockModuleOutput()
+        view = MockViewController()
+        presenter?.view = view
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        presenter = nil
+        view = nil
+    }
+
+    // MARK: - Main tests
+
+    func testThatPresenterHandlesViewLoadedEvent() {
+        // when 
+        presenter?.viewLoaded()
+        // then
+        XCTAssertTrue((presenter?.view as? MockViewController)?.setupInitialStateWasCalled == true)
+    }
+
+    // MARK: - Mocks
+
+    private final class MockViewController: {{ module_info.name }}ViewInput {
+        var setupInitialStateWasCalled: Bool = false
+
+        func setupInitialState() {
+            setupInitialStateWasCalled = true
+        }
+    }
+
+    private final class MockModuleOutput {
+
+    }
+
+}

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Tests/View/view_tests.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Tests/View/view_tests.swift.liquid
@@ -1,0 +1,49 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import XCTest
+@testable import {{ module_info.product_module_name }}
+
+final class {{ module_info.name }}ViewTests: XCTestCase {
+
+    // MARK: - Properties
+
+    private var view: {{ module_info.name }}ViewController?
+    private var output: {{ module_info.name }}ViewOutputMock?
+
+    // MARK: - XCTestCase
+
+    override func setUp() {
+        super.setUp()
+        view = {{ module_info.name }}ViewController()
+        output = {{ module_info.name }}ViewOutputMock()
+        view?.output = output
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        view = nil
+        output = nil
+    }
+
+    // MARK: - Main tests
+
+    func testThatViewNotifiesPresenterOnDidLoad() {
+        // when
+        self.view?.viewDidLoad()
+        // then
+        XCTAssert(self.output?.viewLoadedWasCalled == true)
+    }
+
+    // MARK: - Mocks
+
+    final class {{ module_info.name }}ViewOutputMock: {{ module_info.name }}ViewOutput {
+        var viewLoadedWasCalled: Bool = false
+
+        func viewLoaded() {
+            viewLoadedWasCalled = true
+        }
+    }
+
+}

--- a/surf_mvp_coordinatable_module_mm_custom_headers/surf_mvp_coordinatable_module_mm_custom_headers.rambaspec
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/surf_mvp_coordinatable_module_mm_custom_headers.rambaspec
@@ -1,0 +1,36 @@
+# Template information section
+name: "surf_mvp_coordinatable_module_mm_custom_headers"
+summary: "Template for creating MVP modules with coordinator."
+author: "Serge Nanaev"
+version: "1.0.0"
+license: "MIT"
+
+# The declarations for code files
+
+code_files:
+# Configurator
+- {name: Configurator/ModuleConfigurator.swift, path: Code/Configurator/module_configurator.swift.liquid}
+
+# Presenter layer
+- {name: Presenter/Presenter.swift, path: Code/Presenter/presenter.swift.liquid}
+- {name: Presenter/ModuleInput.swift, path: Code/Presenter/module_input.swift.liquid}
+- {name: Presenter/ModuleOutput.swift, path: Code/Presenter/module_output.swift.liquid}
+
+# View layer
+- {name: View/ViewController.swift, path: Code/View/view_controller.swift.liquid}
+- {name: View/ViewController.xib, path: Code/View/view_controller.xib.liquid}
+- {name: View/ViewInput.swift,  path: Code/View/view_input.swift.liquid}
+- {name: View/ViewOutput.swift, path: Code/View/view_output.swift.liquid}
+
+# The declarations for test files
+
+test_files:
+
+# Configurators tests
+- {name: Configurator/ModuleConfiguratorTests.swift, path: Tests/Configurator/module_configurator_tests.swift.liquid}
+
+# Presenter tests
+#- {name: Presenter/PresenterTests.swift, path: Tests/Presenter/presenter_tests.swift.liquid}
+
+# View tests
+#- {name: View/ViewTests.swift, path: Tests/View/view_tests.swift.liquid}

--- a/surf_mvp_coordinator_custom_headers/Code/coordinator.swift.liquid
+++ b/surf_mvp_coordinator_custom_headers/Code/coordinator.swift.liquid
@@ -1,0 +1,34 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+final class {{ module_info.name }}Coordinator: BaseCoordinator, {{ module_info.name }}CoordinatorOutput {
+
+    // MARK: - {{ module_info.name }}CoordinatorOutput
+
+    // MARK: - Private Properties
+
+    private let router: Router
+
+    // MARK: - Initialization
+
+    init(router: Router) {
+        self.router = router
+    }
+
+    // MARK: - Coordinator
+
+    override func start(with deepLinkOption: DeepLinkOption?) {
+        showModule()
+    }
+
+}
+
+// MARK: - Private Methods
+
+private extension {{ module_info.name }}Coordinator {
+
+    func showModule() {
+    }
+
+}

--- a/surf_mvp_coordinator_custom_headers/Code/coordinator_output.swift.liquid
+++ b/surf_mvp_coordinator_custom_headers/Code/coordinator_output.swift.liquid
@@ -1,0 +1,6 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+protocol {{ module_info.name }}CoordinatorOutput: class {
+}

--- a/surf_mvp_coordinator_custom_headers/surf_mvp_coordinator_custom_headers.rambaspec
+++ b/surf_mvp_coordinator_custom_headers/surf_mvp_coordinator_custom_headers.rambaspec
@@ -1,0 +1,12 @@
+# Template information section
+name: "surf_mvp_coordinator_custom_headers"
+summary: "Template for creating coordinator."
+author: "Alexander Chausov"
+version: "1.0.0"
+license: "MIT"
+
+# The declarations for code files
+
+code_files:
+- {name: Coordinator.swift, path: Code/coordinator.swift.liquid}
+- {name: CoordinatorOutput.swift, path: Code/coordinator_output.swift.liquid}

--- a/surf_mvp_coordinator_mm_custom_headers/Code/coordinator.swift.liquid
+++ b/surf_mvp_coordinator_mm_custom_headers/Code/coordinator.swift.liquid
@@ -1,0 +1,35 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+public final class {{ module_info.name }}Coordinator: BaseCoordinator, {{ module_info.name }}CoordinatorOutput {
+
+    // MARK: - {{ module_info.name }}CoordinatorOutput
+
+    // MARK: - Private Properties
+
+    private let router: Router
+
+    // MARK: - Initialization
+
+    public init(router: Router) {
+        self.router = router
+        super.init()
+    }
+
+    // MARK: - Coordinator
+
+    override public func start(with deepLinkOption: DeepLinkOption?) {
+        showModule()
+    }
+
+}
+
+// MARK: - Private Methods
+
+private extension {{ module_info.name }}Coordinator {
+
+    func showModule() {
+    }
+
+}

--- a/surf_mvp_coordinator_mm_custom_headers/Code/coordinator_output.swift.liquid
+++ b/surf_mvp_coordinator_mm_custom_headers/Code/coordinator_output.swift.liquid
@@ -1,0 +1,6 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+public protocol {{ module_info.name }}CoordinatorOutput: class {
+}

--- a/surf_mvp_coordinator_mm_custom_headers/surf_mvp_coordinator_mm_custom_headers.rambaspec
+++ b/surf_mvp_coordinator_mm_custom_headers/surf_mvp_coordinator_mm_custom_headers.rambaspec
@@ -1,0 +1,12 @@
+# Template information section
+name: "surf_mvp_coordinator_mm_custom_headers"
+summary: "Template for creating coordinator."
+author: "Alexander Chausov"
+version: "1.0.0"
+license: "MIT"
+
+# The declarations for code files
+
+code_files:
+- {name: Coordinator.swift, path: Code/coordinator.swift.liquid}
+- {name: CoordinatorOutput.swift, path: Code/coordinator_output.swift.liquid}


### PR DESCRIPTION
Здесь сделал две вещи:
- поменял в одном месте расположение модификатора public, чтобы везде было `public final class`
- и добавил клоны существующих шаблонов для координаторов, у которых header файла короче и состоит только лишь из copyright