### PR TITLE
Обновил шаблоны

### DIFF
--- a/surf_mvp_coordinatable_alert/Code/Configurator/module_configurator.swift.liquid
+++ b/surf_mvp_coordinatable_alert/Code/Configurator/module_configurator.swift.liquid
@@ -8,9 +8,14 @@
 
 import UIKit
 
+typealias {{ module_info.name }}ModuleComponents = (
+    view: {{ module_info.name }}Controller,
+    output: {{ module_info.name }}ModuleOutput
+)
+
 final class {{ module_info.name }}ModuleConfigurator {
 
-    func configure() -> ({{ module_info.name }}Controller, {{ module_info.name }}ModuleOutput) {
+    func configure() -> {{ module_info.name }}ModuleComponents {
 
         // TODO: Change title and message
         let view = {{ module_info.name }}Controller(title: nil, message: nil, preferredStyle: .alert)

--- a/surf_mvp_coordinatable_alert/Code/Configurator/module_test_configurator.swift.liquid
+++ b/surf_mvp_coordinatable_alert/Code/Configurator/module_test_configurator.swift.liquid
@@ -1,0 +1,20 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import UIKit
+
+public final class {{ module_info.name }}ModuleTestConfigurator {
+
+    // MARK: - Initializer
+
+    public init() {}
+
+    // MARK: - Public methods
+
+    public func configure() -> (UIViewController, [AnyObject]) {
+        let (view, output) = {{ module_info.name }}ModuleConfigurator().configure()
+        return (view, [output])
+    }
+
+}

--- a/surf_mvp_coordinatable_alert/Tests/Configurator/module_deallocation_tests.swift.liquid
+++ b/surf_mvp_coordinatable_alert/Tests/Configurator/module_deallocation_tests.swift.liquid
@@ -9,14 +9,13 @@
 import XCTest
 @testable import {{ module_info.product_module_name  }}
 
-final class {{ module_info.name }}ModuleConfiguratorTests: XCTestCase {
+final class {{ module_info.name }}ModuleDeallocationTests: XCTestCase {
 
     // MARK: - Main tests
 
     func testDeallocation() {
         assertDeallocation(of: {
-            let (view, output) = {{ module_info.name }}ModuleConfigurator().configure()
-            return (view, [output])
+            return {{ module_info.name }}ModuleTestConfigurator().configure()
         })
     }
 

--- a/surf_mvp_coordinatable_alert/surf_mvp_coordinatable_alert.rambaspec
+++ b/surf_mvp_coordinatable_alert/surf_mvp_coordinatable_alert.rambaspec
@@ -10,6 +10,7 @@ license: "MIT"
 code_files:
 # Configurator
 - {name: Configurator/ModuleConfigurator.swift, path: Code/Configurator/module_configurator.swift.liquid}
+- {name: Configurator/ModuleTestConfigurator.swift, path: Code/Configurator/module_test_configurator.swift.liquid}
 
 # Presenter layer
 - {name: Presenter/Presenter.swift, path: Code/Presenter/presenter.swift.liquid}
@@ -26,4 +27,4 @@ code_files:
 test_files:
 
 # Configurators tests
-- {name: Configurator/ModuleConfiguratorTests.swift, path: Tests/Configurator/module_configurator_tests.swift.liquid}
+- {name: Configurator/ModuleDeallocationTests.swift, path: Tests/Configurator/module_deallocation_tests.swift.liquid}

--- a/surf_mvp_coordinatable_alert_custom_headers/Code/Configurator/module_configurator.swift.liquid
+++ b/surf_mvp_coordinatable_alert_custom_headers/Code/Configurator/module_configurator.swift.liquid
@@ -4,9 +4,14 @@
 
 import UIKit
 
+typealias {{ module_info.name }}ModuleComponents = (
+    view: {{ module_info.name }}Controller,
+    output: {{ module_info.name }}ModuleOutput
+)
+
 final class {{ module_info.name }}ModuleConfigurator {
 
-    func configure() -> ({{ module_info.name }}Controller, {{ module_info.name }}ModuleOutput) {
+    func configure() -> {{ module_info.name }}ModuleComponents {
 
         // TODO: Change title and message
         let view = {{ module_info.name }}Controller(title: nil, message: nil, preferredStyle: .alert)

--- a/surf_mvp_coordinatable_alert_custom_headers/Code/Configurator/module_test_configurator.swift.liquid
+++ b/surf_mvp_coordinatable_alert_custom_headers/Code/Configurator/module_test_configurator.swift.liquid
@@ -1,0 +1,20 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import UIKit
+
+public final class {{ module_info.name }}ModuleTestConfigurator {
+
+    // MARK: - Initializer
+
+    public init() {}
+
+    // MARK: - Public methods
+
+    public func configure() -> (UIViewController, [AnyObject]) {
+        let (view, output) = {{ module_info.name }}ModuleConfigurator().configure()
+        return (view, [output])
+    }
+
+}

--- a/surf_mvp_coordinatable_alert_custom_headers/Tests/Configurator/module_deallocation_tests.swift.liquid
+++ b/surf_mvp_coordinatable_alert_custom_headers/Tests/Configurator/module_deallocation_tests.swift.liquid
@@ -5,14 +5,13 @@
 import XCTest
 @testable import {{ module_info.product_module_name  }}
 
-final class {{ module_info.name }}ModuleConfiguratorTests: XCTestCase {
+final class {{ module_info.name }}ModuleDeallocationTests: XCTestCase {
 
     // MARK: - Main tests
 
     func testDeallocation() {
         assertDeallocation(of: {
-            let (view, output) = {{ module_info.name }}ModuleConfigurator().configure()
-            return (view, [output])
+            return {{ module_info.name }}ModuleTestConfigurator().configure()
         })
     }
 

--- a/surf_mvp_coordinatable_alert_custom_headers/surf_mvp_coordinatable_alert_custom_headers.rambaspec
+++ b/surf_mvp_coordinatable_alert_custom_headers/surf_mvp_coordinatable_alert_custom_headers.rambaspec
@@ -10,6 +10,7 @@ license: "MIT"
 code_files:
 # Configurator
 - {name: Configurator/ModuleConfigurator.swift, path: Code/Configurator/module_configurator.swift.liquid}
+- {name: Configurator/ModuleTestConfigurator.swift, path: Code/Configurator/module_test_configurator.swift.liquid}
 
 # Presenter layer
 - {name: Presenter/Presenter.swift, path: Code/Presenter/presenter.swift.liquid}
@@ -26,4 +27,4 @@ code_files:
 test_files:
 
 # Configurators tests
-- {name: Configurator/ModuleConfiguratorTests.swift, path: Tests/Configurator/module_configurator_tests.swift.liquid}
+- {name: Configurator/ModuleDeallocationTests.swift, path: Tests/Configurator/module_deallocation_tests.swift.liquid}

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Configurator/module_configurator.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Configurator/module_configurator.swift.liquid
@@ -4,15 +4,14 @@
 
 import UIKit
 
-public final class {{ module_info.name }}ModuleConfigurator {
+typealias {{ module_info.name }}ModuleComponents = (
+    view: {{ module_info.name }}Controller,
+    output: {{ module_info.name }}ModuleOutput
+)
 
-    // MARK: - Initialization
+final class {{ module_info.name }}ModuleConfigurator {
 
-    public init() {}
-
-    // MARK: - Public Methods
-
-    public func configure() -> (UIAlertController, {{ module_info.name }}ModuleOutput) {
+    func configure() -> {{ module_info.name }}ModuleComponents {
 
         // TODO: Change title and message
         let view = {{ module_info.name }}Controller(title: nil, message: nil, preferredStyle: .alert)

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Configurator/module_test_configurator.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Configurator/module_test_configurator.swift.liquid
@@ -4,11 +4,15 @@
 
 import UIKit
 
-final class {{ module_info.name }}ModuleTestConfigurator {
+public final class {{ module_info.name }}ModuleTestConfigurator {
+
+    // MARK: - Initializer
+
+    public init() {}
 
     // MARK: - Public methods
 
-    func configure() -> (UIViewController, [AnyObject]) {
+    public func configure() -> (UIViewController, [AnyObject]) {
         let (view, output) = {{ module_info.name }}ModuleConfigurator().configure()
         return (view, [output])
     }

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Presenter/module_input.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Presenter/module_input.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-public protocol {{ module_info.name }}ModuleInput: class {
+protocol {{ module_info.name }}ModuleInput: class {
 }

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Presenter/module_output.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Presenter/module_output.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-public protocol {{ module_info.name }}ModuleOutput: class {
+protocol {{ module_info.name }}ModuleOutput: class {
 }

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Tests/Configurator/module_deallocation_tests.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Tests/Configurator/module_deallocation_tests.swift.liquid
@@ -6,14 +6,13 @@ import XCTest
 import {{ custom_parameters.testTarget }}Flow
 @testable import {{ module_info.product_module_name }}
 
-final class {{ module_info.name }}ModuleConfiguratorTests: XCTestCase {
+final class {{ module_info.name }}ModuleDeallocationTests: XCTestCase {
 
     // MARK: - Main tests
 
     func testDeallocation() {
         assertDeallocation(of: {
-            let (view, output) = {{ module_info.name }}ModuleConfigurator().configure()
-            return (view, [output])
+            return {{ module_info.name }}ModuleTestConfigurator().configure()
         })
     }
 

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/surf_mvp_coordinatable_alert_mm_custom_headers.rambaspec
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/surf_mvp_coordinatable_alert_mm_custom_headers.rambaspec
@@ -10,6 +10,7 @@ license: "MIT"
 code_files:
 # Configurator
 - {name: Configurator/ModuleConfigurator.swift, path: Code/Configurator/module_configurator.swift.liquid}
+- {name: Configurator/ModuleTestConfigurator.swift, path: Code/Configurator/module_test_configurator.swift.liquid}
 
 # Presenter layer
 - {name: Presenter/Presenter.swift, path: Code/Presenter/presenter.swift.liquid}
@@ -26,4 +27,4 @@ code_files:
 test_files:
 
 # Configurators tests
-- {name: Configurator/ModuleConfiguratorTests.swift, path: Tests/Configurator/module_configurator_tests.swift.liquid}
+- {name: Configurator/ModuleDeallocationTests.swift, path: Tests/Configurator/module_deallocation_tests.swift.liquid}

--- a/surf_mvp_coordinatable_module_custom_headers/Code/Configurator/module_configurator.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Code/Configurator/module_configurator.swift.liquid
@@ -4,10 +4,15 @@
 
 import UIKit
 
+typealias {{ module_info.name }}ModuleComponents = (
+    view: UIViewController,
+    output: {{ module_info.name }}ModuleOutput
+)
+
 final class {{ module_info.name }}ModuleConfigurator {
 
-    func configure() -> (UIViewController, {{ module_info.name }}ModuleOutput) {
-        let view = {{ module_info.name }}ViewController()
+    func configure() -> {{ module_info.name }}ModuleComponents {
+        let view = UIViewController.instantiate(ofType: {{ module_info.name }}ViewController.self)
         let presenter = {{ module_info.name }}Presenter()
 
         presenter.view = view

--- a/surf_mvp_coordinatable_module_custom_headers/Code/Configurator/module_test_configurator.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Code/Configurator/module_test_configurator.swift.liquid
@@ -1,0 +1,20 @@
+//
+//  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
+//
+
+import UIKit
+
+public final class {{ module_info.name }}ModuleTestConfigurator {
+
+    // MARK: - Initializer
+
+    public init() {}
+
+    // MARK: - Public methods
+
+    public func configure() -> (UIViewController, [AnyObject]) {
+        let (view, output) = {{ module_info.name }}ModuleConfigurator().configure()
+        return (view, [output])
+    }
+
+}

--- a/surf_mvp_coordinatable_module_custom_headers/Tests/Configurator/module_deallocation_tests.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Tests/Configurator/module_deallocation_tests.swift.liquid
@@ -5,14 +5,13 @@
 import XCTest
 @testable import {{ module_info.product_module_name  }}
 
-final class {{ module_info.name }}ModuleConfiguratorTests: XCTestCase {
+final class {{ module_info.name }}ModuleDeallocationTests: XCTestCase {
 
     // MARK: - Main tests
 
     func testDeallocation() {
         assertDeallocation(of: {
-            let (view, output) = {{ module_info.name }}ModuleConfigurator().configure()
-            return (view, [output])
+            return {{ module_info.name }}ModuleTestConfigurator().configure()
         })
     }
 

--- a/surf_mvp_coordinatable_module_custom_headers/surf_mvp_coordinatable_module_custom_headers.rambaspec
+++ b/surf_mvp_coordinatable_module_custom_headers/surf_mvp_coordinatable_module_custom_headers.rambaspec
@@ -10,6 +10,7 @@ license: "MIT"
 code_files:
 # Configurator
 - {name: Configurator/ModuleConfigurator.swift, path: Code/Configurator/module_configurator.swift.liquid}
+- {name: Configurator/ModuleTestConfigurator.swift, path: Code/Configurator/module_test_configurator.swift.liquid}
 
 # Presenter layer
 - {name: Presenter/Presenter.swift, path: Code/Presenter/presenter.swift.liquid}
@@ -27,7 +28,7 @@ code_files:
 test_files:
 
 # Configurators tests
-- {name: Configurator/ModuleConfiguratorTests.swift, path: Tests/Configurator/module_configurator_tests.swift.liquid}
+- {name: Configurator/ModuleDeallocationTests.swift, path: Tests/Configurator/module_deallocation_tests.swift.liquid}
 
 # Presenter tests
 #- {name: Presenter/PresenterTests.swift, path: Tests/Presenter/presenter_tests.swift.liquid}

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/Configurator/module_configurator.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/Configurator/module_configurator.swift.liquid
@@ -4,16 +4,15 @@
 
 import UIKit
 
-public final class {{ module_info.name }}ModuleConfigurator {
+typealias {{ module_info.name }}ModuleComponents = (
+    view: UIViewController,
+    output: {{ module_info.name }}ModuleOutput
+)
 
-    // MARK: - Initialization
+final class {{ module_info.name }}ModuleConfigurator {
 
-    public init() {}
-
-    // MARK: - Public Methods
-
-    public func configure() -> (UIViewController, {{ module_info.name }}ModuleOutput) {
-        let view = {{ module_info.name }}ViewController(nibName: {{ module_info.name }}ViewController.nameOfClass, bundle: Bundle(for: {{ module_info.name }}ViewController.self))
+    func configure() -> {{ module_info.name }}ModuleComponents {
+        let view = UIViewController.instantiate(ofType: {{ module_info.name }}ViewController.self)
         let presenter = {{ module_info.name }}Presenter()
 
         presenter.view = view

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/Configurator/module_test_configurator.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/Configurator/module_test_configurator.swift.liquid
@@ -4,11 +4,15 @@
 
 import UIKit
 
-final class {{ module_info.name }}ModuleTestConfigurator {
+public final class {{ module_info.name }}ModuleTestConfigurator {
+
+    // MARK: - Initializer
+
+    public init() {}
 
     // MARK: - Public methods
 
-    func configure() -> (UIViewController, [AnyObject]) {
+    public func configure() -> (UIViewController, [AnyObject]) {
         let (view, output) = {{ module_info.name }}ModuleConfigurator().configure()
         return (view, [output])
     }

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/Presenter/module_input.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/Presenter/module_input.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-public protocol {{ module_info.name }}ModuleInput: class {
+protocol {{ module_info.name }}ModuleInput: class {
 }

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/Presenter/module_output.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/Presenter/module_output.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-public protocol {{ module_info.name }}ModuleOutput: class {
+protocol {{ module_info.name }}ModuleOutput: class {
 }

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Tests/Configurator/module_deallocation_tests.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Tests/Configurator/module_deallocation_tests.swift.liquid
@@ -6,14 +6,13 @@ import XCTest
 import {{ custom_parameters.testTarget }}Flow
 @testable import {{ module_info.product_module_name }}
 
-final class {{ module_info.name }}ModuleConfiguratorTests: XCTestCase {
+final class {{ module_info.name }}ModuleDeallocationTests: XCTestCase {
 
     // MARK: - Main tests
 
     func testDeallocation() {
         assertDeallocation(of: {
-            let (view, output) = {{ module_info.name }}ModuleConfigurator().configure()
-            return (view, [output])
+            return {{ module_info.name }}ModuleTestConfigurator().configure()
         })
     }
 

--- a/surf_mvp_coordinatable_module_mm_custom_headers/surf_mvp_coordinatable_module_mm_custom_headers.rambaspec
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/surf_mvp_coordinatable_module_mm_custom_headers.rambaspec
@@ -10,6 +10,7 @@ license: "MIT"
 code_files:
 # Configurator
 - {name: Configurator/ModuleConfigurator.swift, path: Code/Configurator/module_configurator.swift.liquid}
+- {name: Configurator/ModuleTestConfigurator.swift, path: Code/Configurator/module_test_configurator.swift.liquid}
 
 # Presenter layer
 - {name: Presenter/Presenter.swift, path: Code/Presenter/presenter.swift.liquid}
@@ -27,7 +28,7 @@ code_files:
 test_files:
 
 # Configurators tests
-- {name: Configurator/ModuleConfiguratorTests.swift, path: Tests/Configurator/module_configurator_tests.swift.liquid}
+- {name: Configurator/ModuleDeallocationTests.swift, path: Tests/Configurator/module_deallocation_tests.swift.liquid}
 
 # Presenter tests
 #- {name: Presenter/PresenterTests.swift, path: Tests/Presenter/presenter_tests.swift.liquid}


### PR DESCRIPTION
## Изменения:

- инициализация UIViewController через внутрениий extension
- конфигураторы теперь возвращают кортеж с элементами
- в каждом модуле теперь есть TestModuleConfigurator, который используется для инициализации тестов на deallocation
- убраны public модификаторы доступа со всех файлов (кроме TestModuleConfigurator)