### PR TITLE
changed class notation on anyObject notation ot avoid warning on new XCode

### DIFF
--- a/surf_mvp_coordinatable_alert_custom_headers/Code/Presenter/module_input.swift.liquid
+++ b/surf_mvp_coordinatable_alert_custom_headers/Code/Presenter/module_input.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-protocol {{ module_info.name }}ModuleInput: class {
+protocol {{ module_info.name }}ModuleInput: AnyObject {
 }

--- a/surf_mvp_coordinatable_alert_custom_headers/Code/Presenter/module_output.swift.liquid
+++ b/surf_mvp_coordinatable_alert_custom_headers/Code/Presenter/module_output.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-protocol {{ module_info.name }}ModuleOutput: class {
+protocol {{ module_info.name }}ModuleOutput: AnyObject {
 }

--- a/surf_mvp_coordinatable_alert_custom_headers/Code/View/view_input.swift.liquid
+++ b/surf_mvp_coordinatable_alert_custom_headers/Code/View/view_input.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-protocol {{ module_info.name }}ViewInput: class {
+protocol {{ module_info.name }}ViewInput: AnyObject {
 }

--- a/surf_mvp_coordinatable_alert_custom_headers/Code/View/view_output.swift.liquid
+++ b/surf_mvp_coordinatable_alert_custom_headers/Code/View/view_output.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-protocol {{ module_info.name }}ViewOutput: class {
+protocol {{ module_info.name }}ViewOutput: AnyObject {
 }

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Presenter/module_input.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Presenter/module_input.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-protocol {{ module_info.name }}ModuleInput: class {
+protocol {{ module_info.name }}ModuleInput: AnyObject {
 }

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Presenter/module_output.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Code/Presenter/module_output.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-protocol {{ module_info.name }}ModuleOutput: class {
+protocol {{ module_info.name }}ModuleOutput: AnyObject {
 }

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Code/View/view_input.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Code/View/view_input.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-protocol {{ module_info.name }}ViewInput: class {
+protocol {{ module_info.name }}ViewInput: AnyObject {
 }

--- a/surf_mvp_coordinatable_alert_mm_custom_headers/Code/View/view_output.swift.liquid
+++ b/surf_mvp_coordinatable_alert_mm_custom_headers/Code/View/view_output.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-protocol {{ module_info.name }}ViewOutput: class {
+protocol {{ module_info.name }}ViewOutput: AnyObject {
 }

--- a/surf_mvp_coordinatable_module_custom_headers/Code/Presenter/module_input.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Code/Presenter/module_input.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-protocol {{ module_info.name }}ModuleInput: class {
+protocol {{ module_info.name }}ModuleInput: AnyObject {
 }

--- a/surf_mvp_coordinatable_module_custom_headers/Code/Presenter/module_output.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Code/Presenter/module_output.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-protocol {{ module_info.name }}ModuleOutput: class {
+protocol {{ module_info.name }}ModuleOutput: AnyObject {
 }

--- a/surf_mvp_coordinatable_module_custom_headers/Code/View/view_input.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Code/View/view_input.swift.liquid
@@ -2,7 +2,6 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-protocol {{ module_info.name }}ViewInput: class {
-    /// Method for setup initial state of view
+protocol {{ module_info.name }}ViewInput: AnyObject {
     func setupInitialState()
 }

--- a/surf_mvp_coordinatable_module_custom_headers/Code/View/view_output.swift.liquid
+++ b/surf_mvp_coordinatable_module_custom_headers/Code/View/view_output.swift.liquid
@@ -3,6 +3,5 @@
 //
 
 protocol {{ module_info.name }}ViewOutput {
-    /// Notify presenter that view is ready
     func viewLoaded()
 }

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/Presenter/module_input.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/Presenter/module_input.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-protocol {{ module_info.name }}ModuleInput: class {
+protocol {{ module_info.name }}ModuleInput: AnyObject {
 }

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/Presenter/module_output.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/Presenter/module_output.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-protocol {{ module_info.name }}ModuleOutput: class {
+protocol {{ module_info.name }}ModuleOutput: AnyObject {
 }

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/View/view_input.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/View/view_input.swift.liquid
@@ -2,7 +2,6 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-protocol {{ module_info.name }}ViewInput: class {
-    /// Method for setup initial state of view
+protocol {{ module_info.name }}ViewInput: AnyObject {
     func setupInitialState()
 }

--- a/surf_mvp_coordinatable_module_mm_custom_headers/Code/View/view_output.swift.liquid
+++ b/surf_mvp_coordinatable_module_mm_custom_headers/Code/View/view_output.swift.liquid
@@ -3,6 +3,5 @@
 //
 
 protocol {{ module_info.name }}ViewOutput {
-    /// Notify presenter that view is ready
     func viewLoaded()
 }

--- a/surf_mvp_coordinator_custom_headers/Code/coordinator_output.swift.liquid
+++ b/surf_mvp_coordinator_custom_headers/Code/coordinator_output.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-protocol {{ module_info.name }}CoordinatorOutput: class {
+protocol {{ module_info.name }}CoordinatorOutput: AnyObject {
 }

--- a/surf_mvp_coordinator_mm_custom_headers/Code/coordinator_output.swift.liquid
+++ b/surf_mvp_coordinator_mm_custom_headers/Code/coordinator_output.swift.liquid
@@ -2,5 +2,5 @@
 //  Copyright © {{ year }} {{ developer.company }}. All rights reserved.
 //
 
-public protocol {{ module_info.name }}CoordinatorOutput: class {
+public protocol {{ module_info.name }}CoordinatorOutput: AnyObject {
 }


### PR DESCRIPTION
Новый xcode выдает ошибку “Using ‘class’ keyword for protocol inheritance is deprecated; use ‘AnyObject’ instead”

Так что заменяем в текущих актальных шаблонах class на AnyObject.
Попутно снесены бесполезные комментарии